### PR TITLE
Adding absolute path for ansible galaxy so it does not fail on path issues

### DIFF
--- a/ansible/roles/squid/tasks/main.yml
+++ b/ansible/roles/squid/tasks/main.yml
@@ -23,6 +23,6 @@
     - requirements.yml
 
 - name: Setup deployment playbook dependancies (2/2)
-  command: "ansible-galaxy install -f -r {{ansible_deploy_playbook_directory}}/requirements.yml"
+  command: "/usr/local/bin/ansible-galaxy install -f -r {{ansible_deploy_playbook_directory}}/requirements.yml"
   register: requirements_output
   changed_when: '"was installed successfully" in requirements_output.stdout'


### PR DESCRIPTION
Adding absolute path for ansible galaxy so it does not fail on path issues